### PR TITLE
fix: call BIO_free on the correct NativeLibrary object

### DIFF
--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -408,8 +408,8 @@ class _DtlsClientConnection extends Stream<Datagram> implements DtlsConnection {
       DtlsClient._connections.remove(address);
     }
 
-    libSsl
-      ..SSL_free(_ssl)
+    libSsl.SSL_free(_ssl);
+    libCrypto
       ..BIO_free(_rbio)
       ..BIO_free(_wbio);
     _ssl = nullptr;


### PR DESCRIPTION
This fixes a small bug introduced in #5 that caused errors when trying to access the `BIO_free` function.