### PR TITLE
feat!: improve memory safety of DtlsClientContext

### DIFF
--- a/test/dtls_test.dart
+++ b/test/dtls_test.dart
@@ -10,6 +10,5 @@ void main() {
     final context = DtlsClientContext();
     final dtlsClient = await DtlsClient.bind("::", 0, context);
     dtlsClient.close();
-    context.free();
   });
 }


### PR DESCRIPTION
This PR applies a couple of (breaking) changes to the DtlsClientContext class, making it unnecessary in the new version to call the `free()` method (which is therefore removed).