### PR TITLE
fix!: make connection closing asynchronous

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -31,10 +31,10 @@ void main() async {
   final connection = await dtlsClient.connect(peerAddr, peerPort);
 
   connection
-    ..listen((datagram) {
+    ..listen((datagram) async {
       print('> ${utf8.decode(datagram.data)}');
-      connection.close();
       print('Connection closed');
+      await connection.close();
     }, onDone: () {
       dtlsClient.close();
       print('Client closed');

--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -115,14 +115,14 @@ class DtlsClient {
   ///
   /// [RawDatagramSocket]s that have been passed in by the user are only closed
   /// if [closeExternalSocket] is set to `true`.
-  void close({bool closeExternalSocket = false}) {
+  Future<void> close({bool closeExternalSocket = false}) async {
     if (_closed) {
       return;
     }
 
     for (final connection in _connectionCache.values) {
       _connections.remove(connection._ssl.address);
-      connection.close(closedByClient: true);
+      await connection.close(closedByClient: true);
     }
 
     _connectionCache.clear();
@@ -404,7 +404,6 @@ class _DtlsClientConnection extends Stream<Datagram> implements DtlsConnection {
     }
 
     _timer?.cancel();
-    await _received.close();
 
     if (!closedByClient) {
       // This distinction is made to avoid concurrent modification errors.
@@ -416,6 +415,7 @@ class _DtlsClientConnection extends Stream<Datagram> implements DtlsConnection {
 
     _closed = true;
     _connected = false;
+    await _received.close();
   }
 
   void _maintainOutgoing() {

--- a/lib/src/dtls_connection.dart
+++ b/lib/src/dtls_connection.dart
@@ -19,5 +19,5 @@ abstract class DtlsConnection extends Stream<Datagram> {
   int send(List<int> data);
 
   /// Closes this [DtlsConnection].
-  void close();
+  Future<void> close();
 }

--- a/test/dtls_test.dart
+++ b/test/dtls_test.dart
@@ -9,6 +9,6 @@ void main() {
   test('create and free context and connection', () async {
     final context = DtlsClientContext();
     final dtlsClient = await DtlsClient.bind("::", 0, context);
-    dtlsClient.close();
+    await dtlsClient.close();
   });
 }


### PR DESCRIPTION
This PR makes the use of the `close()` method on `DtlsConnection`s more consistent by changing the return type to `Future<void>`. Before, the implementation could lead to some inconsistencies due to a non-awaited closing of the internal `StreamController` in the `_DtlsClientConnection` class.