### PR TITLE
feat: look for multiple default OpenSSL file names

### DIFF
--- a/lib/dtls2.dart
+++ b/lib/dtls2.dart
@@ -4,4 +4,5 @@
 
 export 'src/dtls_client.dart';
 export 'src/dtls_connection.dart';
+export 'src/openssl_load_exception.dart';
 export 'src/psk_credentials.dart';

--- a/lib/src/openssl_load_exception.dart
+++ b/lib/src/openssl_load_exception.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 Jan Romann
+// SPDX-License-Identifier: MIT
+
+/// This [Exception] is thrown if there is an error loading
+/// either libssl or libcrypto.
+///
+/// Using an [Exception] instead of an [Error] allows users
+/// to provide a fallback or throw their own [Exception]s
+/// if OpenSSL should not be available.
+class OpenSslLoadException implements Exception {
+  /// The actual error message.
+  final String libName;
+
+  /// Constructor.
+  OpenSslLoadException(this.libName);
+
+  @override
+  String toString() {
+    return "$runtimeType: Could not find $libName.";
+  }
+}


### PR DESCRIPTION
This should basic macOS support to the library and make it compatible with OpenSSL 3 (which is preferred over OpenSSL 1.1.1).

Better testing needs to be added in follow-up PRs.