### PR TITLE
feat: allow passing custom libSsl and libCrypto objects

### DIFF
--- a/lib/src/lib.dart
+++ b/lib/src/lib.dart
@@ -8,8 +8,6 @@ import 'dart:io';
 import 'generated/ffi.dart';
 import 'openssl_load_exception.dart';
 
-export 'generated/ffi.dart';
-
 NativeLibrary _loadLibrary(List<String> libNames, String libName) {
   for (final libName in libNames) {
     try {


### PR DESCRIPTION
This PR allows users to pass custom `NativeLibrary` objects when instantiating `DtlsClient`s, allowing them to provide an alternative from the default library loading logic.