### PR TITLE
chore: also run CI on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -22,6 +25,11 @@ jobs:
 
       - name: Analyze project source
         run: dart analyze
+
+      - name: Install OpenSSL (Windows)
+        run: |
+          choco install openssl
+        if: ${{ matrix.os == 'windows-latest' }}
 
       - name: Run tests with coverage
         run: dart test --coverage="coverage"


### PR DESCRIPTION
This adds two additional CI workflows, testing the package not only on Linux but also on macOS and Windows.