### PR TITLE
fix: fix macOS homebrew paths

### DIFF
--- a/lib/src/lib.dart
+++ b/lib/src/lib.dart
@@ -31,10 +31,9 @@ NativeLibrary _loadLibSsl() {
   if (Platform.isWindows) {
     libNames = const ['libssl-3-x64.dll', 'libssl-1_1-x64.dll'];
   } else if (Platform.isMacOS) {
-    // TODO(JKRhb): Check if these are working
     libNames = const [
-      '/usr/local/lib/libssl.3.dylib',
-      '/usr/local/lib/libssl.1.1.dylib',
+      '/usr/local/opt/openssl@3/lib/libssl.3.dylib',
+      '/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib',
       'libssl.3.dylib',
       'libssl.1.1.dylib',
     ];
@@ -56,10 +55,9 @@ NativeLibrary _loadLibCrypto() {
   if (Platform.isWindows) {
     libNames = const ['libcrypto-3-x64.dll', 'libcrypto-1_1-x64.dll'];
   } else if (Platform.isMacOS) {
-    // TODO(JKRhb): Check if these are working
     libNames = const [
-      '/usr/local/lib/libcrypto.3.dylib',
-      '/usr/local/lib/libcrypto.1.1.dylib',
+      '/usr/local/opt/openssl@3/lib/libcrypto.3.dylib',
+      '/usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib',
       'libcrypto.3.dylib',
       'libcrypto.1.1.dylib',
     ];


### PR DESCRIPTION
This adjusts some of the libssl and libcrypto paths for macOS, making it possible to use the homebrew-installed OpenSSL versions 1.1 and 3.

This aspect is still not ideal, I think, but users are able to make their own adjustments due to the custom `NativeLibrary` arguments introduced in #12.