### PR TITLE
fix: don't iterate over connection cache for incoming data

### DIFF
--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -102,7 +102,10 @@ class DtlsClient {
       if (event == RawSocketEvent.read) {
         final data = _socket.receive();
         if (data != null) {
-          for (final connection in _connectionCache.values) {
+          final key = getConnectionKey(data.address, data.port);
+          final connection = _connectionCache[key];
+
+          if (connection != null) {
             _incoming(data.data, connection);
           }
         }


### PR DESCRIPTION
This PR fixes a small potential issue that could cause problems if multiple connections have been established by a single DtlsClient.