### PR TITLE
feat: shutdown SSL connection upon closing

### DIFF
--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -447,6 +447,10 @@ class _DtlsClientConnection extends Stream<Datagram> implements DtlsConnection {
       _dtlsClient._connectionCache.remove(address);
     }
 
+    _libSsl.SSL_shutdown(_ssl);
+
+    _maintainState();
+
     _libSsl.SSL_free(_ssl);
 
     _closed = true;

--- a/lib/src/generated/ffi.dart
+++ b/lib/src/generated/ffi.dart
@@ -481,6 +481,20 @@ class OpenSsl {
   late final _DTLS_client_method =
       _DTLS_client_methodPtr.asFunction<ffi.Pointer<SSL_METHOD> Function()>();
 
+  int SSL_shutdown(
+    ffi.Pointer<SSL> s,
+  ) {
+    return _SSL_shutdown(
+      s,
+    );
+  }
+
+  late final _SSL_shutdownPtr =
+      _lookup<ffi.NativeFunction<ffi.Int32 Function(ffi.Pointer<SSL>)>>(
+          'SSL_shutdown');
+  late final _SSL_shutdown =
+      _SSL_shutdownPtr.asFunction<int Function(ffi.Pointer<SSL>)>();
+
   int SSL_CTX_set_default_verify_paths(
     ffi.Pointer<SSL_CTX> ctx,
   ) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ ffigen:
       - SSL_connect
       - SSL_ctrl
       - SSL_free
+      - SSL_shutdown
       - SSL_get0_param
       - SSL_get_error
       - SSL_new


### PR DESCRIPTION
This PR lets the DtlsClient send a close notify alert to its peer upon closing, causing connections to be shutdown more gracefully.