### PR TITLE
fix: fix hostname verfication of X.509 certificates

### DIFF
--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -226,7 +226,7 @@ class _DtlsClientConnection extends Stream<Datagram> implements DtlsConnection {
     if (hostname != null) {
       final hostnameStr = hostname.toNativeUtf8();
       _libCrypto.X509_VERIFY_PARAM_set1_host(
-          _libSsl.SSL_get0_param(_ssl), hostnameStr.cast(), nullptr);
+          _libSsl.SSL_get0_param(_ssl), hostnameStr.cast(), hostnameStr.length);
       _libSsl.SSL_ctrl(_ssl, SSL_CTRL_SET_TLSEXT_HOSTNAME,
           TLSEXT_NAMETYPE_host_name, hostnameStr.cast());
       malloc.free(hostnameStr);

--- a/lib/src/generated/ffi.dart
+++ b/lib/src/generated/ffi.dart
@@ -139,7 +139,7 @@ class OpenSsl {
   int X509_VERIFY_PARAM_set1_host(
     ffi.Pointer<X509_VERIFY_PARAM> param,
     ffi.Pointer<ffi.Int8> name,
-    ffi.Pointer<size_t> namelen,
+    int namelen,
   ) {
     return _X509_VERIFY_PARAM_set1_host(
       param,
@@ -150,14 +150,12 @@ class OpenSsl {
 
   late final _X509_VERIFY_PARAM_set1_hostPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<X509_VERIFY_PARAM>,
-              ffi.Pointer<ffi.Int8>,
-              ffi.Pointer<size_t>)>>('X509_VERIFY_PARAM_set1_host');
+          ffi.Int32 Function(ffi.Pointer<X509_VERIFY_PARAM>,
+              ffi.Pointer<ffi.Int8>, size_t)>>('X509_VERIFY_PARAM_set1_host');
   late final _X509_VERIFY_PARAM_set1_host =
       _X509_VERIFY_PARAM_set1_hostPtr.asFunction<
-          int Function(ffi.Pointer<X509_VERIFY_PARAM>, ffi.Pointer<ffi.Int8>,
-              ffi.Pointer<size_t>)>();
+          int Function(
+              ffi.Pointer<X509_VERIFY_PARAM>, ffi.Pointer<ffi.Int8>, int)>();
 
   void X509_free(
     ffi.Pointer<X509> a,
@@ -566,7 +564,7 @@ typedef X509_VERIFY_PARAM = X509_VERIFY_PARAM_st;
 
 class X509_VERIFY_PARAM_st extends ffi.Opaque {}
 
-typedef size_t = ffi.NativeFunction<ffi.Int32 Function()>;
+typedef size_t = ffi.Uint64;
 typedef SSL_CTX = ssl_ctx_st;
 
 class ssl_ctx_st extends ffi.Opaque {}


### PR DESCRIPTION
This PR corrects a call of the `X509_VERIFY_PARAM_set1_host` function, now using the hostname length as a parameter. In the process, the OpenSSL bindings are regenerated, fixing the binding signature of the function in question.