### PR TITLE
feat!: don't expose `OpenSsl` ffi class

### DIFF
--- a/lib/dtls2.dart
+++ b/lib/dtls2.dart
@@ -4,6 +4,5 @@
 
 export 'src/dtls_client.dart';
 export 'src/dtls_connection.dart';
-export 'src/generated/ffi.dart' show OpenSsl;
 export 'src/openssl_load_exception.dart';
 export 'src/psk_credentials.dart';


### PR DESCRIPTION
This PR reduces the API surface of the library by reverting the exposure of the `OpenSsl` class (which has become obsolete due to #24).