### PR TITLE
feat!: pass `DtlsClientContext` to `connect` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ void main() async {
       (await InternetAddress.lookup(hostname)).first;
   final peerPort = 5684;
 
-  final dtlsClient = await DtlsClient.bind('::', 0, context);
+  final dtlsClient = await DtlsClient.bind('::', 0);
 
-  final connection = await dtlsClient.connect(peerAddr, peerPort);
+  final connection = await dtlsClient.connect(peerAddr, peerPort, context);
 
   connection
     ..listen((datagram) async {

--- a/example/example.dart
+++ b/example/example.dart
@@ -26,9 +26,9 @@ void main() async {
       (await InternetAddress.lookup(hostname)).first;
   final peerPort = 5684;
 
-  final dtlsClient = await DtlsClient.bind('::', 0, context);
+  final dtlsClient = await DtlsClient.bind('::', 0);
 
-  final connection = await dtlsClient.connect(peerAddr, peerPort);
+  final connection = await dtlsClient.connect(peerAddr, peerPort, context);
 
   connection
     ..listen((datagram) async {

--- a/test/dtls_test.dart
+++ b/test/dtls_test.dart
@@ -7,8 +7,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('create and free context and connection', () async {
-    final context = DtlsClientContext();
-    final dtlsClient = await DtlsClient.bind("::", 0, context);
+    final dtlsClient = await DtlsClient.bind("::", 0);
     await dtlsClient.close();
   });
 }


### PR DESCRIPTION
This PR moves the `context` argument from the `DtlsClient` to its `connect` method, making it easier to define different security contexts and PSK callbacks for each connection.