### PR TITLE
refactor: refactor DTLS client

### DIFF
--- a/lib/src/buffer.dart
+++ b/lib/src/buffer.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 Jan Romann
+// Copyright (c) 2021 Famedly GmbH
+// SPDX-License-Identifier: MIT
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+/// Size of the global buffer used for interacting with OpenSSL.
+const bufferSize = (1 << 16);
+
+/// Global buffer used for interacting with OpenSSL.
+final Pointer<Uint8> buffer = malloc.call<Uint8>(bufferSize);

--- a/lib/src/psk_credentials.dart
+++ b/lib/src/psk_credentials.dart
@@ -6,9 +6,8 @@ import 'dart:typed_data';
 /// Function signature for a callback function for retrieving/generating
 /// [PskCredentials].
 ///
-/// As the format of the [identityHint] is not well-defined, this parameter
-/// can probably be ignored in most cases, when both the identity and the key
-/// are known in advance.
+/// Servers might provide an [identityHint] that contains information on how
+/// to generate the credentials.
 typedef PskCredentialsCallback = PskCredentials Function(
   Uint8List identityHint,
 );

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -3,8 +3,24 @@
 
 import 'dart:io';
 
+import 'generated/ffi.dart';
+
 /// Creates a string key from an [address] and [port] intended for caching a
 /// connection.
 String getConnectionKey(InternetAddress address, int port) {
   return "${address.address}:$port";
 }
+
+/// Extension for an easier conversion from [timeval] structs to [Duration]
+/// objects.
+extension DurationTimeval on timeval {
+  /// Converts this [timeval] struct to a [Duration] object.
+  Duration get duration =>
+      Duration(seconds: tv_sec) + Duration(microseconds: tv_usec);
+}
+
+bool _isFatalAlert(int ret) => ret << 8 == SSL3_AL_FATAL;
+bool _isCloseNotify(int ret) => ret & 0xff == SSL_AD_CLOSE_NOTIFY;
+
+/// Determines if a DTLS alarm code requires closing the connection.
+bool requiresClosing(int ret) => _isFatalAlert(ret) || _isCloseNotify(ret);


### PR DESCRIPTION
This PR moves some definitions to shared files for both client and server (in preparation of #28) and slightly improves the documentation of the `PskCredentialsCallback` type definition.