### PR TITLE
fix: close client and server when the underlying socket is closed

### DIFF
--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -87,16 +87,25 @@ class DtlsClient {
 
   void _startListening() {
     _socket.listen((event) async {
-      if (event == RawSocketEvent.read) {
-        final data = _socket.receive();
-        if (data != null) {
-          final key = getConnectionKey(data.address, data.port);
-          final connection = _connectionCache[key];
+      switch (event) {
+        case RawSocketEvent.read:
+          final data = _socket.receive();
+          if (data != null) {
+            final key = getConnectionKey(data.address, data.port);
+            final connection = _connectionCache[key];
 
-          if (connection != null) {
-            connection._incoming(data.data);
+            if (connection != null) {
+              connection._incoming(data.data);
+            }
           }
-        }
+
+          break;
+        case RawSocketEvent.closed:
+          await close();
+          break;
+        case RawSocketEvent.readClosed:
+        case RawSocketEvent.write:
+          break;
       }
     });
   }


### PR DESCRIPTION
This PR should mitigate potential problems that could arise if a socket that is used by a `DtlsClient` or `DtlsServer` is closed while keeping the corresponding client or server open.