### PR TITLE
fix(dtls_client): throw exception if no ciphers are available

### DIFF
--- a/lib/src/generated/ffi.dart
+++ b/lib/src/generated/ffi.dart
@@ -635,6 +635,22 @@ class OpenSsl {
   late final _DTLS_client_method =
       _DTLS_client_methodPtr.asFunction<ffi.Pointer<SSL_METHOD> Function()>();
 
+  ffi.Pointer<stack_st_SSL_CIPHER> SSL_get1_supported_ciphers(
+    ffi.Pointer<SSL> s,
+  ) {
+    return _SSL_get1_supported_ciphers(
+      s,
+    );
+  }
+
+  late final _SSL_get1_supported_ciphersPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<stack_st_SSL_CIPHER> Function(
+              ffi.Pointer<SSL>)>>('SSL_get1_supported_ciphers');
+  late final _SSL_get1_supported_ciphers =
+      _SSL_get1_supported_ciphersPtr.asFunction<
+          ffi.Pointer<stack_st_SSL_CIPHER> Function(ffi.Pointer<SSL>)>();
+
   int SSL_shutdown(
     ffi.Pointer<SSL> s,
   ) {
@@ -785,6 +801,8 @@ typedef SSL_verify_cb = ffi.Pointer<
 typedef X509_STORE_CTX = x509_store_ctx_st;
 
 class x509_store_ctx_st extends ffi.Opaque {}
+
+class stack_st_SSL_CIPHER extends ffi.Opaque {}
 
 const int BIO_C_SET_BUF_MEM_EOF_RETURN = 130;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ ffigen:
       - SSL_read
       - SSL_set_bio
       - SSL_write
+      - SSL_get1_supported_ciphers
       - X509_VERIFY_PARAM_set1_host
       - SSL_CTX_get_cert_store
       - SSL_set_psk_client_callback


### PR DESCRIPTION
This PR mitigates a problem that could occur if you limit the client to PSK ciphers without providing a `pskCredentialsCallback` argument. In this case, the client showed strange behavior and sent empty client hello messages. This PR fixes the issue by throwing an exception instead and providing a hint to the user how they can deal with the problem.