### PR TITLE
fix: export `DtlsException` class

### DIFF
--- a/lib/dtls2.dart
+++ b/lib/dtls2.dart
@@ -4,6 +4,7 @@
 
 export 'src/dtls_client.dart';
 export 'src/dtls_connection.dart';
+export 'src/dtls_exception.dart';
 export 'src/dtls_server.dart';
 export 'src/openssl_load_exception.dart';
 export 'src/psk_credentials.dart';


### PR DESCRIPTION
For some reason, the `DtlsException` class was not exported and therefore could not be used by library users. This PR fixes the problem.