### PR TITLE
feat!: simplify identity hint determination

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -34,6 +34,7 @@ final context = DtlsClientContext(
   withTrustedRoots: true,
   ciphers: _ciphers,
   pskCredentialsCallback: (identityHint) {
+    print(identityHint);
     return PskCredentials(
       identity: Uint8List.fromList(utf8.encode(_identity)),
       preSharedKey: Uint8List.fromList(utf8.encode(_preSharedKey)),
@@ -52,6 +53,7 @@ void main() async {
       DtlsServerContext(
         pskKeyStoreCallback: _serverPskCallback,
         ciphers: _ciphers,
+        identityHint: "This is the identity hint!",
       ));
 
   dtlsServer.listen(

--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -307,30 +307,12 @@ class _DtlsClientConnection extends Stream<Datagram> implements DtlsConnection {
     }
   }
 
-  static Uint8List _determineIdentityHint(
-    Pointer<Char> hint,
-    int maxIdentityLength,
-  ) {
+  static String? _determineIdentityHint(Pointer<Char> hint) {
     if (hint == nullptr) {
-      return Uint8List(0);
+      return null;
     }
 
-    final identityHintBytes = <int>[];
-    const nullTerminator = 0;
-    var index = 0;
-
-    while (index < maxIdentityLength) {
-      final currentValue = hint.elementAt(index).value;
-      identityHintBytes.add(currentValue);
-
-      if (currentValue == nullTerminator) {
-        break;
-      }
-
-      index++;
-    }
-
-    return Uint8List.fromList(identityHintBytes);
+    return hint.cast<Utf8>().toDartString();
   }
 
   static int _pskCallback(
@@ -346,7 +328,7 @@ class _DtlsClientConnection extends Stream<Datagram> implements DtlsConnection {
       throw StateError("No DTLS Connection found for SSL object!");
     }
 
-    final identityHint = _determineIdentityHint(hint, maxIdentityLength);
+    final identityHint = _determineIdentityHint(hint);
 
     final pskCredentials =
         connection._pskCredentialsCallback?.call(identityHint);

--- a/lib/src/psk_credentials.dart
+++ b/lib/src/psk_credentials.dart
@@ -9,7 +9,7 @@ import 'dart:typed_data';
 /// Servers might provide an [identityHint] that contains information on how
 /// to generate the credentials.
 typedef PskCredentialsCallback = PskCredentials Function(
-  Uint8List identityHint,
+  String? identityHint,
 );
 
 /// Credentials used for PSK Cipher Suites consisting of an [identity]


### PR DESCRIPTION
Since OpenSSL apparently only passes null-terminated strings as the identity hint to PSK callbacks, this PR simplifies the process of obtaining the identity hint and introduces a slight (but breaking) API change to the `PskCredentialsCallback` type definition.