### PR TITLE
feat!: do not use typed_data types for external APIs

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:dtls2/dtls2.dart';
 
@@ -17,8 +16,8 @@ final _serverKeyStore = {_identity: _preSharedKey};
 
 const _ciphers = "PSK-AES128-CCM8";
 
-Uint8List? _serverPskCallback(Uint8List identity) {
-  final identityString = utf8.decode(identity.toList());
+Iterable<int>? _serverPskCallback(List<int> identity) {
+  final identityString = utf8.decode(identity);
 
   final psk = _serverKeyStore[identityString];
 
@@ -26,7 +25,7 @@ Uint8List? _serverPskCallback(Uint8List identity) {
     return null;
   }
 
-  return Uint8List.fromList(utf8.encode(psk));
+  return utf8.encode(psk);
 }
 
 final context = DtlsClientContext(
@@ -36,8 +35,8 @@ final context = DtlsClientContext(
   pskCredentialsCallback: (identityHint) {
     print(identityHint);
     return PskCredentials(
-      identity: Uint8List.fromList(utf8.encode(_identity)),
-      preSharedKey: Uint8List.fromList(utf8.encode(_preSharedKey)),
+      identity: utf8.encode(_identity),
+      preSharedKey: utf8.encode(_preSharedKey),
     );
   },
 );
@@ -61,7 +60,7 @@ void main() async {
       connection.listen(
         (event) async {
           print(utf8.decode(event.data));
-          connection.send(Uint8List.fromList(utf8.encode('Bye World')));
+          connection.send(utf8.encode('Bye World'));
           await connection.close();
         },
         onDone: () async {
@@ -100,5 +99,5 @@ void main() async {
         print('Client closed.');
       },
     )
-    ..send(Uint8List.fromList(utf8.encode('Hello World')));
+    ..send(utf8.encode('Hello World'));
 }

--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -340,20 +340,20 @@ class _DtlsClientConnection extends Stream<Datagram> implements DtlsConnection {
     final connectionIdentity = pskCredentials.identity;
     final connectionPsk = pskCredentials.preSharedKey;
 
-    if (connectionIdentity.lengthInBytes > maxIdentityLength ||
-        connectionPsk.lengthInBytes > maxPskLength) {
+    if (connectionIdentity.length > maxIdentityLength ||
+        connectionPsk.length > maxPskLength) {
       return _pskErrorCode;
     }
 
     identity
         .cast<Uint8>()
-        .asTypedList(connectionIdentity.lengthInBytes)
+        .asTypedList(connectionIdentity.length)
         .setAll(0, connectionIdentity);
     psk
         .cast<Uint8>()
-        .asTypedList(connectionPsk.lengthInBytes)
+        .asTypedList(connectionPsk.length)
         .setAll(0, connectionPsk);
-    return connectionPsk.lengthInBytes;
+    return connectionPsk.length;
   }
 
   void _handleAlert(DtlsAlert event) {

--- a/lib/src/dtls_server.dart
+++ b/lib/src/dtls_server.dart
@@ -21,7 +21,7 @@ import 'util.dart';
 
 /// Callback signature for retrieving Pre-Shared Keys from a [DtlsServer]'s
 /// keystore.
-typedef PskKeyStoreCallback = Uint8List? Function(Uint8List identity);
+typedef PskKeyStoreCallback = Iterable<int>? Function(List<int> identity);
 
 /// Provides DTLS server functionality based on OpenSSL.
 ///
@@ -510,7 +510,7 @@ int _pskCallback(Pointer<SSL> ssl, Pointer<Char> identity,
     return -1;
   }
 
-  final pskLength = pskCredentials.lengthInBytes;
+  final pskLength = pskCredentials.length;
 
   psk.cast<Uint8>().asTypedList(pskLength).setAll(0, pskCredentials);
   return pskLength;

--- a/lib/src/psk_credentials.dart
+++ b/lib/src/psk_credentials.dart
@@ -1,8 +1,6 @@
 // Copyright (c) 2023 Jan Romann
 // SPDX-License-Identifier: MIT
 
-import 'dart:typed_data';
-
 /// Function signature for a callback function for retrieving/generating
 /// [PskCredentials].
 ///
@@ -16,10 +14,10 @@ typedef PskCredentialsCallback = PskCredentials Function(
 /// and a [preSharedKey].
 class PskCredentials {
   /// The identity used with the [preSharedKey].
-  Uint8List identity;
+  Iterable<int> identity;
 
   /// The actual pre-shared key.
-  Uint8List preSharedKey;
+  Iterable<int> preSharedKey;
 
   /// Constructor
   PskCredentials({required this.identity, required this.preSharedKey});

--- a/test/dtls_test.dart
+++ b/test/dtls_test.dart
@@ -21,7 +21,7 @@ final serverKeyStore = {identity: preSharedKey};
 
 final bindAddress = InternetAddress.anyIPv4;
 
-Uint8List? _serverPskCallback(Uint8List identity) {
+Iterable<int>? _serverPskCallback(Iterable<int> identity) {
   final identityString = utf8.decode(identity.toList());
 
   final psk = serverKeyStore[identityString];
@@ -30,7 +30,7 @@ Uint8List? _serverPskCallback(Uint8List identity) {
     return null;
   }
 
-  return Uint8List.fromList(utf8.encode(psk));
+  return utf8.encode(psk);
 }
 
 final clientContext = DtlsClientContext(


### PR DESCRIPTION
Library users currently need to import `dart:typed_data` as a dependency in order to use both client and server PSK callbacks, since they are using `Uint8List` for input and output types.

This PR gets rid of the need for additional dependencies by relying on `Iterable<int>` and `List<int>` instead, which also increases the range of allowed types (and, e.g., also includes `Uint8Buffer`s).