### PR TITLE
feat!: rework library loading

### DIFF
--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -15,7 +15,7 @@ import 'buffer.dart';
 import 'dtls_alert.dart';
 import 'dtls_exception.dart';
 import 'generated/ffi.dart';
-import 'lib.dart' as lib;
+import 'lib.dart';
 import 'psk_credentials.dart';
 import 'util.dart';
 
@@ -52,8 +52,8 @@ class DtlsClient {
     this._socket, {
     DynamicLibrary? libSsl,
     DynamicLibrary? libCrypto,
-  })  : _libCrypto = _loadOpenSsl(libCrypto) ?? lib.libCrypto,
-        _libSsl = _loadOpenSsl(libSsl) ?? lib.libSsl {
+  })  : _libCrypto = loadLibCrypto(libCrypto),
+        _libSsl = loadLibSsl(libSsl) {
     _startListening();
   }
 
@@ -126,14 +126,6 @@ class DtlsClient {
   final OpenSsl _libSsl;
 
   final OpenSsl _libCrypto;
-
-  static OpenSsl? _loadOpenSsl(DynamicLibrary? dynamicLibrary) {
-    if (dynamicLibrary == null) {
-      return null;
-    }
-
-    return OpenSsl(dynamicLibrary);
-  }
 
   /// Closes this [DtlsClient].
   ///

--- a/lib/src/dtls_server.dart
+++ b/lib/src/dtls_server.dart
@@ -16,7 +16,7 @@ import 'dtls_alert.dart';
 import 'dtls_connection.dart';
 import 'dtls_exception.dart';
 import 'generated/ffi.dart';
-import 'lib.dart' as lib;
+import 'lib.dart';
 import 'util.dart';
 
 /// Callback signature for retrieving Pre-Shared Keys from a [DtlsServer]'s
@@ -33,11 +33,11 @@ class DtlsServer extends Stream<DtlsConnection> {
   DtlsServer(
     this._socket,
     this._context, {
-    OpenSsl? libSsl,
-    OpenSsl? libCrypto,
-  })  : _sslContext = _context._generateSslContext(libSsl ?? lib.libSsl),
-        _libCrypto = libCrypto ?? lib.libCrypto,
-        _libSsl = libSsl ?? lib.libSsl {
+    DynamicLibrary? libSsl,
+    DynamicLibrary? libCrypto,
+  })  : _sslContext = _context._generateSslContext(loadLibSsl(libSsl)),
+        _libCrypto = loadLibCrypto(libCrypto),
+        _libSsl = loadLibSsl(libSsl) {
     const error = -1;
 
     _libSsl
@@ -88,8 +88,8 @@ class DtlsServer extends Stream<DtlsConnection> {
     int port,
     DtlsServerContext context, {
     int ttl = 1,
-    OpenSsl? libCrypto,
-    OpenSsl? libSsl,
+    DynamicLibrary? libCrypto,
+    DynamicLibrary? libSsl,
   }) async {
     final socket = await RawDatagramSocket.bind(host, port, ttl: ttl);
     return DtlsServer(

--- a/lib/src/lib.dart
+++ b/lib/src/lib.dart
@@ -69,7 +69,27 @@ OpenSsl _loadLibCrypto() {
 }
 
 /// The global libssl object.
-final libSsl = _loadLibSsl();
+final _libSsl = _loadLibSsl();
 
 /// The global libcrypto object.
-final libCrypto = _loadLibCrypto();
+final _libCrypto = _loadLibCrypto();
+
+OpenSsl _loadOpenSsl(DynamicLibrary? dynamicLibrary, OpenSsl defaultLibrary) {
+  if (dynamicLibrary == null) {
+    return defaultLibrary;
+  }
+
+  return OpenSsl(dynamicLibrary);
+}
+
+/// Tries to load libcrypto from a [dynamicLibrary].
+///
+/// If that fails, the function tries to load libcrypto from a default location.
+OpenSsl loadLibCrypto(final DynamicLibrary? dynamicLibrary) =>
+    _loadOpenSsl(dynamicLibrary, _libCrypto);
+
+/// Tries to load libssl from a [dynamicLibrary].
+///
+/// If that fails, the function tries to load libssl from a default location.
+OpenSsl loadLibSsl(final DynamicLibrary? dynamicLibrary) =>
+    _loadOpenSsl(dynamicLibrary, _libSsl);


### PR DESCRIPTION
Building upon #46, this PR makes loading `libcrypto` and `libssl` on the server-side more flexible by changing the constructor argument types from `OpenSsl` to `DynamicLibrary`. The PR also applies some minor refactorings and improves the internal API for loading `libcrypto` and `libssl`.