### PR TITLE
docs: add library documentation

### DIFF
--- a/lib/dtls2.dart
+++ b/lib/dtls2.dart
@@ -2,6 +2,9 @@
 // Copyright (c) 2021 Famedly GmbH
 // SPDX-License-Identifier: MIT
 
+/// A DTLS library for Dart, implemented via FFI bindings to OpenSSL.
+library dtls2;
+
 export 'src/dtls_client.dart';
 export 'src/dtls_connection.dart';
 export 'src/dtls_exception.dart';


### PR DESCRIPTION
This PR adds a missing `library` keyword and corresponding documentation to the package.