### PR TITLE
feat: add bindings to OpenSSL version functions

### DIFF
--- a/lib/src/generated/ffi.dart
+++ b/lib/src/generated/ffi.dart
@@ -22,6 +22,50 @@ class OpenSsl {
           lookup)
       : _lookup = lookup;
 
+  int OPENSSL_version_major() {
+    return _OPENSSL_version_major();
+  }
+
+  late final _OPENSSL_version_majorPtr =
+      _lookup<ffi.NativeFunction<ffi.UnsignedInt Function()>>(
+          'OPENSSL_version_major');
+  late final _OPENSSL_version_major =
+      _OPENSSL_version_majorPtr.asFunction<int Function()>();
+
+  int OPENSSL_version_minor() {
+    return _OPENSSL_version_minor();
+  }
+
+  late final _OPENSSL_version_minorPtr =
+      _lookup<ffi.NativeFunction<ffi.UnsignedInt Function()>>(
+          'OPENSSL_version_minor');
+  late final _OPENSSL_version_minor =
+      _OPENSSL_version_minorPtr.asFunction<int Function()>();
+
+  int OPENSSL_version_patch() {
+    return _OPENSSL_version_patch();
+  }
+
+  late final _OPENSSL_version_patchPtr =
+      _lookup<ffi.NativeFunction<ffi.UnsignedInt Function()>>(
+          'OPENSSL_version_patch');
+  late final _OPENSSL_version_patch =
+      _OPENSSL_version_patchPtr.asFunction<int Function()>();
+
+  ffi.Pointer<ffi.Char> OpenSSL_version(
+    int type,
+  ) {
+    return _OpenSSL_version(
+      type,
+    );
+  }
+
+  late final _OpenSSL_versionPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function(ffi.Int)>>(
+          'OpenSSL_version');
+  late final _OpenSSL_version =
+      _OpenSSL_versionPtr.asFunction<ffi.Pointer<ffi.Char> Function(int)>();
+
   ffi.Pointer<BIO> BIO_new(
     ffi.Pointer<BIO_METHOD> type,
   ) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,9 @@ ffigen:
       - SSL_CTX_set_psk_server_callback
       - SSL_CTX_use_psk_identity_hint
       - SSL_set_accept_state
+      - OPENSSL_version_major
+      - OPENSSL_version_minor
+      - OPENSSL_version_patch
   macros:
     include:
       - BIO_C_SET_BUF_MEM_EOF_RETURN


### PR DESCRIPTION
Similar to the suggestion by @Ifilehk in #49, this PR adds FFI bindings to the OpenSSL functions for determining the major, minor, and patch versions.