### PR TITLE
chore: ignore ffi bindings for code coverage

### DIFF
--- a/lib/src/generated/ffi.dart
+++ b/lib/src/generated/ffi.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 // ignore_for_file: camel_case_types, non_constant_identifier_names
 // ignore_for_file: constant_identifier_names, public_member_api_docs
 // ignore_for_file: unused_field, lines_longer_than_80_chars

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ ffigen:
       - /usr/include/openssl/evp.h
       - /usr/include/openssl/err.h
   preamble: |
+    // coverage:ignore-file
     // ignore_for_file: camel_case_types, non_constant_identifier_names
     // ignore_for_file: constant_identifier_names, public_member_api_docs
     // ignore_for_file: unused_field, lines_longer_than_80_chars


### PR DESCRIPTION
This PR lets the code coverage tool ignore the auto-generated bindings, some of which might not get used in practice.