### PR TITLE
chore(server): remove commented out code

### DIFF
--- a/lib/src/dtls_server.dart
+++ b/lib/src/dtls_server.dart
@@ -117,8 +117,6 @@ class DtlsServer extends Stream<DtlsConnection> {
         }
 
         final ssl = _libSsl.SSL_new(_sslContext);
-        // _libSsl.SSL_set_options(ssl, SSL_OP_COOKIE_EXCHANGE);
-
         connection = _DtlsServerConnection(
           this,
           address,
@@ -262,9 +260,6 @@ class _DtlsServerConnection extends Stream<Datagram> implements DtlsConnection {
   }
 
   void _maintainState() {
-    // SSL_CTX_set_options(ctx, SSL_OP_NO_QUERY_MTU);
-    // DTLS_set_link_mtu(this->handle, mtu)
-
     if (_connectCompleter.isCompleted) {
       final ret = _libSsl.SSL_read(_ssl, buffer.cast(), bufferSize);
       if (ret > 0) {


### PR DESCRIPTION
This PR performs a bit of cleanup in `dtls_server.dart`.