### PR TITLE
ci: simplify code coverage generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,11 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
 
       - name: Run tests with coverage
-        run: dart test --coverage="coverage"
-
-      - name: Convert coverage to ICOV
-        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --report-on=lib
+        run: dart run coverage:test_with_coverage
 
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.lcov
+          file: coverage/lcov.info
           name: Upload to codecov.io
           verbose: true


### PR DESCRIPTION
This PR simplifies the generation of code coverage reports in the CI workflow using `dart run coverage`.