### PR TITLE
refactor: refactor connection closing mechanism

### DIFF
--- a/lib/src/dtls_server.dart
+++ b/lib/src/dtls_server.dart
@@ -185,12 +185,8 @@ class DtlsServer extends Stream<DtlsConnection> {
       return;
     }
 
-    for (final connection in _connectionCache.values) {
-      _connections.remove(connection._ssl.address);
-      await connection.close(closedByServer: true);
-    }
+    await _connectionCache.closeConnections();
 
-    _connectionCache.clear();
     if (!_externalSocket || closeExternalSocket) {
       _socket.close();
     }
@@ -312,19 +308,16 @@ class _DtlsServerConnection extends Stream<Datagram> implements DtlsConnection {
   }
 
   @override
-  Future<void> close({bool closedByServer = false}) async {
+  Future<void> close() async {
     if (_closed) {
       return;
     }
 
     _timer?.cancel();
 
-    if (!closedByServer) {
-      // This distinction is made to avoid concurrent modification errors.
-      DtlsServer._connections.remove(_ssl.address);
-      final connectionCacheKey = getConnectionKey(_address, _port);
-      _dtlsServer._connectionCache.remove(connectionCacheKey);
-    }
+    DtlsServer._connections.remove(_ssl.address);
+    final connectionCacheKey = getConnectionKey(_address, _port);
+    _dtlsServer._connectionCache.remove(connectionCacheKey);
 
     final connected = _connected;
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -3,6 +3,7 @@
 
 import 'dart:io';
 
+import 'dtls_connection.dart';
 import 'generated/ffi.dart';
 
 /// Creates a string key from an [address] and [port] intended for caching a
@@ -25,4 +26,25 @@ extension InfoCallbackUtilities on int {
   /// Determines if the `where` parameter of the info callback is referring to
   /// a DTLS alert.
   bool get isAlert => this & 0x4000 > 0;
+}
+
+/// Extension for a factoring out the closing of all client or server
+/// [DtlsConnection]s.
+extension CloseConnection on Map<String, DtlsConnection> {
+  /// Closes all [DtlsConnection]s registered in this [Map].
+  ///
+  /// When this method is finished, all connections will be/must be removed from
+  /// this [Map].
+  /// Otherwise, a [StateError] is thrown.
+  Future<void> closeConnections() async {
+    final copiedConnectionKeys = keys.toList();
+
+    for (final connectionKey in copiedConnectionKeys) {
+      await this[connectionKey]?.close();
+    }
+
+    if (length > 0) {
+      throw StateError("Not all DTLS connections have been closed!");
+    }
+  }
 }


### PR DESCRIPTION
This PR refactors the process of closing client and server connections, removing the need for additional `closedByClient` or `closedByServer` parameters.