### PR TITLE
chore: use lint package for stricter linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![pub package](https://img.shields.io/pub/v/dtls2.svg)](https://pub.dev/packages/dtls2)
 [![Build](https://github.com/JKRhb/dtls2/actions/workflows/ci.yml/badge.svg)](https://github.com/JKRhb/dtls2/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/JKRhb/dtls2/branch/main/graph/badge.svg?token=76OBNOVL60)](https://codecov.io/gh/JKRhb/dtls2)
+[![style: lint](https://img.shields.io/badge/style-lint-4BC0F5.svg)](https://pub.dev/packages/lint)
 
 # dtls2
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,97 +1,11 @@
-# Copyright (c) 2023 Jan Romann
-# Copyright (c) 2021 Famedly GmbH
-# SPDX-License-Identifier: MIT
+# This file configures the analyzer to use the lint rule set from `package:lint`
 
-include: package:lints/recommended.yaml
+include: package:lint/package.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
-  errors:
-    missing_required_param: warning
-    missing_return: warning
-    package_api_docs: warning
-    public_member_api_docs: warning
-    prefer_interpolation_to_compose_strings: warning
-    unnecessary_lambdas: warning
-    avoid_catches_without_on_clauses: warning
-    avoid_catching_errors: warning
-    prefer_mixin: warning
-    use_setters_to_change_properties: warning
-    avoid_setters_without_getters: warning
-    type_annotate_public_apis: warning
-    always_declare_return_types: warning
-    avoid_void_async: warning
-    only_throw_errors: warning
-    prefer_final_locals: warning
-    prefer_null_aware_method_calls: warning
-    unawaited_futures: warning
-    depend_on_referenced_packages: warning
-    flutter_style_todos: info
-    deprecated_member_use_from_same_package: info
-    todo: ignore
+  exclude:
+    - 'lib/src/generated/ffi.dart'
 
-# Rules in addition to recommended set
 linter:
   rules:
-    - directives_ordering
-    - package_api_docs
-    - public_member_api_docs
-    - comment_references
-    - prefer_interpolation_to_compose_strings
-    - unnecessary_lambdas
-    - lines_longer_than_80_chars
-    - avoid_catches_without_on_clauses  # no pokémon exception handling (at least only catch Exception)
-    - avoid_catching_errors
-    - use_to_and_as_if_applicable  # this rule may cause false positives, if so, just disable it
-    - prefer_mixin
-    - use_setters_to_change_properties
-    - avoid_setters_without_getters  # use a method instead
-    - avoid_returning_this  # use cascades instead
-    - type_annotate_public_apis
-    - avoid_types_on_closure_parameters
-    - avoid_positional_boolean_parameters
-    - avoid_dynamic_calls
-    - avoid_returning_null_for_future
-    - avoid_slow_async_io
-    - cancel_subscriptions
-    - close_sinks
-    - always_declare_return_types
-    - avoid_void_async
-    - cascade_invocations
-    - eol_at_end_of_file
-    - flutter_style_todos
-    - leading_newlines_in_multiline_strings
-    - only_throw_errors
-    - prefer_final_locals
-    - prefer_null_aware_method_calls
-    - unawaited_futures
-    - unnecessary_null_aware_assignments
-    - use_if_null_to_convert_nulls_to_bools
-    - use_is_even_rather_than_modulo
-    - depend_on_referenced_packages
-
-
-dart_code_metrics:
-  anti-patterns:
-    - long-method
-    - long-parameter-list
-  metrics:
-    cyclomatic-complexity: 20
-    maximum-nesting-level: 5
-    number-of-parameters: 4
-    source-lines-of-code: 50
-  metrics-exclude:
-    - test/**
-  rules:
-    - avoid-nested-conditional-expressions:
-        - acceptable-level: 2
-    - avoid-throw-in-catch-block # throwWithStackTrace should be used instead
-    - avoid-unnecessary-type-casts
-    - no-boolean-literal-compare
-    - no-empty-block
-    - no-equal-then-else
-    - no-magic-number:
-        - allowed: [3.14, -1, 0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 100]
-    - prefer-correct-type-name
+    prefer_double_quotes: true

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,11 +2,13 @@
 // Copyright (c) 2021 Famedly GmbH
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
+// ignore_for_file: avoid_print
 
-import 'package:dtls2/dtls2.dart';
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:dtls2/dtls2.dart";
 
 const _identity = "Client_identity";
 
@@ -29,7 +31,6 @@ Iterable<int>? _serverPskCallback(List<int> identity) {
 }
 
 final context = DtlsClientContext(
-  verify: true,
   withTrustedRoots: true,
   ciphers: _ciphers,
   pskCredentialsCallback: (identityHint) {
@@ -44,23 +45,24 @@ final context = DtlsClientContext(
 void main() async {
   const bindAddress = "::";
   final peerAddress = InternetAddress("::1");
-  final peerPort = 5684;
+  const peerPort = 5684;
 
   final dtlsServer = await DtlsServer.bind(
-      bindAddress,
-      peerPort,
-      DtlsServerContext(
-        pskKeyStoreCallback: _serverPskCallback,
-        ciphers: _ciphers,
-        identityHint: "This is the identity hint!",
-      ));
+    bindAddress,
+    peerPort,
+    DtlsServerContext(
+      pskKeyStoreCallback: _serverPskCallback,
+      ciphers: _ciphers,
+      identityHint: "This is the identity hint!",
+    ),
+  );
 
   dtlsServer.listen(
     (connection) {
       connection.listen(
         (event) async {
           print(utf8.decode(event.data));
-          connection.send(utf8.encode('Bye World'));
+          connection.send(utf8.encode("Bye World"));
           await connection.close();
         },
         onDone: () async {
@@ -80,7 +82,7 @@ void main() async {
       peerAddress,
       peerPort,
       context,
-      timeout: Duration(seconds: 5),
+      timeout: const Duration(seconds: 5),
     );
   } on TimeoutException {
     await dtlsClient.close();
@@ -92,12 +94,12 @@ void main() async {
       (datagram) async {
         print(utf8.decode(datagram.data));
         await connection.close();
-        print('Client connection closed.');
+        print("Client connection closed.");
       },
       onDone: () async {
         await dtlsClient.close();
-        print('Client closed.');
+        print("Client closed.");
       },
     )
-    ..send(utf8.encode('Hello World'));
+    ..send(utf8.encode("Hello World"));
 }

--- a/lib/dtls2.dart
+++ b/lib/dtls2.dart
@@ -5,9 +5,9 @@
 /// A DTLS library for Dart, implemented via FFI bindings to OpenSSL.
 library dtls2;
 
-export 'src/dtls_client.dart';
-export 'src/dtls_connection.dart';
-export 'src/dtls_exception.dart';
-export 'src/dtls_server.dart';
-export 'src/openssl_load_exception.dart';
-export 'src/psk_credentials.dart';
+export "src/dtls_client.dart";
+export "src/dtls_connection.dart";
+export "src/dtls_exception.dart";
+export "src/dtls_server.dart";
+export "src/openssl_load_exception.dart";
+export "src/psk_credentials.dart";

--- a/lib/src/buffer.dart
+++ b/lib/src/buffer.dart
@@ -2,12 +2,12 @@
 // Copyright (c) 2021 Famedly GmbH
 // SPDX-License-Identifier: MIT
 
-import 'dart:ffi';
+import "dart:ffi";
 
-import 'package:ffi/ffi.dart';
+import "package:ffi/ffi.dart";
 
 /// Size of the global buffer used for interacting with OpenSSL.
-const bufferSize = (1 << 16);
+const bufferSize = 1 << 16;
 
 /// Global buffer used for interacting with OpenSSL.
 final Pointer<Uint8> buffer = malloc.call<Uint8>(bufferSize);

--- a/lib/src/dtls_alert.dart
+++ b/lib/src/dtls_alert.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 Jan Romann
 // SPDX-License-Identifier: MIT
 
-import 'dart:collection';
+import "dart:collection";
 
 /// The possible DTLS alert levels.
 ///

--- a/lib/src/dtls_connection.dart
+++ b/lib/src/dtls_connection.dart
@@ -1,8 +1,8 @@
 // Copyright (c) 2023 Jan Romann
 // SPDX-License-Identifier: MIT
 
-import 'dart:io';
-import 'dtls_exception.dart';
+import "dart:io";
+import "package:dtls2/src/dtls_exception.dart";
 
 /// Represents a DTLS connection to a peer.
 ///

--- a/lib/src/lib.dart
+++ b/lib/src/lib.dart
@@ -2,11 +2,11 @@
 // Copyright (c) 2021 Famedly GmbH
 // SPDX-License-Identifier: MIT
 
-import 'dart:ffi';
-import 'dart:io';
+import "dart:ffi";
+import "dart:io";
 
-import 'generated/ffi.dart';
-import 'openssl_load_exception.dart';
+import "package:dtls2/src/generated/ffi.dart";
+import "package:dtls2/src/openssl_load_exception.dart";
 
 OpenSsl _loadLibrary(List<String> libNames, String libName) {
   for (final libName in libNames) {
@@ -29,19 +29,19 @@ OpenSsl _loadLibSsl() {
   final List<String> libNames;
 
   if (Platform.isWindows) {
-    libNames = const ['libssl-3-x64.dll', 'libssl-1_1-x64.dll'];
+    libNames = const ["libssl-3-x64.dll", "libssl-1_1-x64.dll"];
   } else if (Platform.isMacOS) {
     libNames = const [
-      '/usr/local/opt/openssl@3/lib/libssl.3.dylib',
-      '/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib',
-      'libssl.3.dylib',
-      'libssl.1.1.dylib',
+      "/usr/local/opt/openssl@3/lib/libssl.3.dylib",
+      "/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib",
+      "libssl.3.dylib",
+      "libssl.1.1.dylib",
     ];
   } else {
-    libNames = const ['libssl.so'];
+    libNames = const ["libssl.so"];
   }
 
-  return _loadLibrary(libNames, 'libssl');
+  return _loadLibrary(libNames, "libssl");
 }
 
 /// Loads libcrypto as an [OpenSsl] object.
@@ -53,19 +53,19 @@ OpenSsl _loadLibCrypto() {
   final List<String> libNames;
 
   if (Platform.isWindows) {
-    libNames = const ['libcrypto-3-x64.dll', 'libcrypto-1_1-x64.dll'];
+    libNames = const ["libcrypto-3-x64.dll", "libcrypto-1_1-x64.dll"];
   } else if (Platform.isMacOS) {
     libNames = const [
-      '/usr/local/opt/openssl@3/lib/libcrypto.3.dylib',
-      '/usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib',
-      'libcrypto.3.dylib',
-      'libcrypto.1.1.dylib',
+      "/usr/local/opt/openssl@3/lib/libcrypto.3.dylib",
+      "/usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib",
+      "libcrypto.3.dylib",
+      "libcrypto.1.1.dylib",
     ];
   } else {
-    libNames = const ['libcrypto.so'];
+    libNames = const ["libcrypto.so"];
   }
 
-  return _loadLibrary(libNames, 'libcrypto');
+  return _loadLibrary(libNames, "libcrypto");
 }
 
 /// The global libssl object.
@@ -85,11 +85,11 @@ OpenSsl _loadOpenSsl(DynamicLibrary? dynamicLibrary, OpenSsl defaultLibrary) {
 /// Tries to load libcrypto from a [dynamicLibrary].
 ///
 /// If that fails, the function tries to load libcrypto from a default location.
-OpenSsl loadLibCrypto(final DynamicLibrary? dynamicLibrary) =>
+OpenSsl loadLibCrypto(DynamicLibrary? dynamicLibrary) =>
     _loadOpenSsl(dynamicLibrary, _libCrypto);
 
 /// Tries to load libssl from a [dynamicLibrary].
 ///
 /// If that fails, the function tries to load libssl from a default location.
-OpenSsl loadLibSsl(final DynamicLibrary? dynamicLibrary) =>
+OpenSsl loadLibSsl(DynamicLibrary? dynamicLibrary) =>
     _loadOpenSsl(dynamicLibrary, _libSsl);

--- a/lib/src/openssl_load_exception.dart
+++ b/lib/src/openssl_load_exception.dart
@@ -16,6 +16,6 @@ class OpenSslLoadException implements Exception {
 
   @override
   String toString() {
-    return "$runtimeType: Could not find $libName.";
+    return "OpenSslLoadException: Could not find $libName.";
   }
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,10 +1,10 @@
 // Copyright (c) 2023 Jan Romann
 // SPDX-License-Identifier: MIT
 
-import 'dart:io';
+import "dart:io";
 
-import 'dtls_connection.dart';
-import 'generated/ffi.dart';
+import "package:dtls2/src/dtls_connection.dart";
+import "package:dtls2/src/generated/ffi.dart";
 
 /// Creates a string key from an [address] and [port] intended for caching a
 /// connection.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 dev_dependencies:
   dart_code_metrics: ^5.4.0
   ffigen: ^7.2.4
-  lints: ^2.0.1
+  lint: ^2.0.0
   test: ^1.16.0
 
 ffigen:

--- a/test/dtls_test.dart
+++ b/test/dtls_test.dart
@@ -2,14 +2,14 @@
 // Copyright (c) 2021 Famedly GmbH
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-import 'dart:typed_data';
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+import "dart:typed_data";
 
-import 'package:dtls2/dtls2.dart';
-import 'package:dtls2/src/dtls_alert.dart';
-import 'package:test/test.dart';
+import "package:dtls2/dtls2.dart";
+import "package:dtls2/src/dtls_alert.dart";
+import "package:test/test.dart";
 
 const ciphers = "PSK-AES128-CCM8";
 
@@ -36,7 +36,6 @@ Iterable<int>? _serverPskCallback(Iterable<int> identity) {
 }
 
 final clientContext = DtlsClientContext(
-  verify: true,
   withTrustedRoots: true,
   ciphers: ciphers,
   pskCredentialsCallback: (receivedIdentityHint) {
@@ -56,13 +55,13 @@ final serverContext = DtlsServerContext(
 );
 
 void main() {
-  test('create and free context and connection', () async {
+  test("create and free context and connection", () async {
     final dtlsClient = await DtlsClient.bind(bindAddress, 0);
     await dtlsClient.close();
   });
 
   test(
-    'Client and server test',
+    "Client and server test",
     () async {
       final completer = Completer<void>();
       const address = "127.0.0.1";
@@ -72,8 +71,8 @@ void main() {
       final dtlsServer =
           await DtlsServer.bind(bindAddress, port, serverContext);
 
-      final clientPayload = "Hello World";
-      final serverPayload = "Bye World";
+      const clientPayload = "Hello World";
+      const serverPayload = "Bye World";
 
       dtlsServer.listen(
         (connection) {
@@ -119,13 +118,15 @@ void main() {
     },
     onPlatform: <String, dynamic>{
       "mac-os": [
-        Skip("on macOS, SSL_connct somehow fails. This needs to be fixed."),
+        const Skip(
+          "on macOS, SSL_connct somehow fails. This needs to be fixed.",
+        ),
       ]
     },
   );
 
-  test('Parse DTLS alerts', () {
-    final code = 1 << 8;
+  test("Parse DTLS alerts", () {
+    const code = 1 << 8;
 
     final alert = DtlsAlert.fromCode(code);
     expect(alert?.alertLevel, AlertLevel.warning);


### PR DESCRIPTION
This PR replaces the `lints` package with the `lint` package for the definition of analysis rules, reducing the number of manually defined rules, and making them more maintainable. At the same time, this makes the applied rules stricter, improving code quality and performance.