### PR TITLE
feat: expose state of connections

### DIFF
--- a/lib/src/dtls_connection.dart
+++ b/lib/src/dtls_connection.dart
@@ -20,4 +20,25 @@ abstract class DtlsConnection extends Stream<Datagram> {
 
   /// Closes this [DtlsConnection].
   Future<void> close();
+
+  /// Indicates the current state of this [DtlsConnection].
+  ConnectionState get state;
+}
+
+/// Indicates the
+enum ConnectionState {
+  /// The connection has not been initialized yet.
+  uninitialized,
+
+  /// The DTLS handshake is currently being performed.
+  handshake,
+
+  /// The handshake was successful, the [DtlsConnection] has been established.
+  connected,
+
+  /// The [DtlsConnection] has been shutdown.
+  ///
+  /// This can either be due to an orderly shutdown or due to an error during
+  /// the handshake process.
+  shutdown,
 }


### PR DESCRIPTION
As requested by @Ifilehk (😉), this PR exposes the state of `DtlsConnection`s, making it possible to check for library users to perform a slightly more fine-grained inspection of both client and server-side connections.

As mentioned in #66, there is still room for improvement when it comes to state management, but for now, I think this PR should be fine to merge.