### PR TITLE
fix(dtls_client): improve error handling

### DIFF
--- a/lib/src/generated/ffi.dart
+++ b/lib/src/generated/ffi.dart
@@ -850,6 +850,8 @@ const int SSL_AD_UNEXPECTED_MESSAGE = 10;
 
 const int SSL_ERROR_SSL = 1;
 
+const int SSL_ERROR_SYSCALL = 5;
+
 const int SSL_ERROR_ZERO_RETURN = 6;
 
 const int SSL_CTRL_SET_TLSEXT_HOSTNAME = 55;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,6 +87,7 @@ ffigen:
       - SSL_CTRL_SET_TLSEXT_HOSTNAME
       - SSL_ERROR_SSL
       - SSL_ERROR_ZERO_RETURN
+      - SSL_ERROR_SYSCALL
       - SSL_VERIFY_NONE
       - SSL_VERIFY_PEER
       - TLSEXT_NAMETYPE_host_name


### PR DESCRIPTION
This PR should be another step towards resolving #66. If a connection attempt fails, a (slightly) better error message should now be thrown and the connection should be cleaned up properly.

There is still some work to be done in order to cover all potential sources of errors, but it should already be a significant improvement compared to the previous state of the library.