### PR TITLE
Make it possible to set the OpenSSL security level 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ const _preSharedKey = "secretPSK";
 
 final _serverKeyStore = {_identity: _preSharedKey};
 
-const _ciphers = "PSK-AES128-CCM8";
-
 Uint8List? _serverPskCallback(Uint8List identity) {
   final identityString = utf8.decode(identity.toList());
 
@@ -106,7 +104,6 @@ Uint8List? _serverPskCallback(Uint8List identity) {
 final context = DtlsClientContext(
   verify: true,
   withTrustedRoots: true,
-  ciphers: _ciphers,
   pskCredentialsCallback: (identityHint) {
     return PskCredentials(
       identity: Uint8List.fromList(utf8.encode(_identity)),
@@ -125,7 +122,6 @@ void main() async {
       peerPort,
       DtlsServerContext(
         pskKeyStoreCallback: _serverPskCallback,
-        ciphers: _ciphers,
       ));
 
   dtlsServer.listen(

--- a/example/example.dart
+++ b/example/example.dart
@@ -18,6 +18,16 @@ final _serverKeyStore = {_identity: _preSharedKey};
 
 const _ciphers = "PSK-AES128-CCM8";
 
+// Needed to still be able to use PSK-AES128-CCM8 as a cipher suite with more
+// recent versions of OpenSSL.
+//
+// In production scenarios, you probably want to use a higher security level
+// and more secure cipher suites instead.
+// For this example, the security level is lowered since `PSK-AES128-CCM8`
+// is the mandatory cipher suite for CoAPS (Constrained Application Protocol,
+// secured with DTLS).
+const securityLevel = 0;
+
 Iterable<int>? _serverPskCallback(List<int> identity) {
   final identityString = utf8.decode(identity);
 
@@ -33,6 +43,7 @@ Iterable<int>? _serverPskCallback(List<int> identity) {
 final context = DtlsClientContext(
   withTrustedRoots: true,
   ciphers: _ciphers,
+  securityLevel: securityLevel,
   pskCredentialsCallback: (identityHint) {
     print(identityHint);
     return PskCredentials(
@@ -54,6 +65,7 @@ void main() async {
       pskKeyStoreCallback: _serverPskCallback,
       ciphers: _ciphers,
       identityHint: "This is the identity hint!",
+      securityLevel: securityLevel,
     ),
   );
 

--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -651,6 +651,7 @@ class DtlsClientContext {
     List<Uint8List> rootCertificates = const [],
     String? ciphers,
     PskCredentialsCallback? pskCredentialsCallback,
+    this.securityLevel,
   })  : _pskCredentialsCallback = pskCredentialsCallback,
         _withTrustedRoots = withTrustedRoots,
         _verify = verify,
@@ -666,6 +667,14 @@ class DtlsClientContext {
   final List<Uint8List> _rootCertificates;
 
   final String? _ciphers;
+
+  /// User-provided security level for OpenSSL.
+  ///
+  /// Influences which key lengths and ciphers suites can be used with this DTLS
+  /// context. See the [OpenSSL documentation] for more information.
+  ///
+  /// [OpenSSL documentation]: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_security_level.html
+  final int? securityLevel;
 
   void _addRoots(
     List<Uint8List> certs,
@@ -711,6 +720,11 @@ class DtlsClientContext {
       final ciphersStr = ciphers.toNativeUtf8();
       libSsl.SSL_CTX_set_cipher_list(ctx, ciphersStr.cast());
       malloc.free(ciphersStr);
+    }
+
+    final securityLevel = this.securityLevel;
+    if (securityLevel != null) {
+      libSsl.SSL_CTX_set_security_level(ctx, securityLevel);
     }
 
     return ctx;

--- a/lib/src/dtls_server.dart
+++ b/lib/src/dtls_server.dart
@@ -460,6 +460,7 @@ class DtlsServerContext {
     String? ciphers,
     PskKeyStoreCallback? pskKeyStoreCallback,
     String? identityHint,
+    this.securityLevel,
   })  : _pskKeyStoreCallback = pskKeyStoreCallback,
         _withTrustedRoots = withTrustedRoots,
         _verify = verify,
@@ -478,6 +479,14 @@ class DtlsServerContext {
   final String? _ciphers;
 
   final String? _identityHint;
+
+  /// User-provided security level for OpenSSL.
+  ///
+  /// Influences which key lengths and ciphers suites can be used with this DTLS
+  /// context. See the [OpenSSL documentation] for more information.
+  ///
+  /// [OpenSSL documentation]: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_security_level.html
+  final int? securityLevel;
 
   void _addRoots(
     List<Uint8List> certs,
@@ -543,6 +552,11 @@ class DtlsServerContext {
       final nativeIdentityHint = identityHint.toNativeUtf8();
       libSsl.SSL_CTX_use_psk_identity_hint(ctx, nativeIdentityHint.cast());
       malloc.free(nativeIdentityHint);
+    }
+
+    final securityLevel = this.securityLevel;
+    if (securityLevel != null) {
+      libSsl.SSL_CTX_set_security_level(ctx, securityLevel);
     }
 
     return ctx;

--- a/lib/src/generated/ffi.dart
+++ b/lib/src/generated/ffi.dart
@@ -748,6 +748,22 @@ class OpenSsl {
   late final _DTLSv1_listen = _DTLSv1_listenPtr.asFunction<
       int Function(ffi.Pointer<SSL>, ffi.Pointer<BIO_ADDR>)>();
 
+  void SSL_CTX_set_security_level(
+    ffi.Pointer<SSL_CTX> ctx,
+    int level,
+  ) {
+    return _SSL_CTX_set_security_level(
+      ctx,
+      level,
+    );
+  }
+
+  late final _SSL_CTX_set_security_levelPtr = _lookup<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<SSL_CTX>, ffi.Int)>>(
+      'SSL_CTX_set_security_level');
+  late final _SSL_CTX_set_security_level = _SSL_CTX_set_security_levelPtr
+      .asFunction<void Function(ffi.Pointer<SSL_CTX>, int)>();
+
   int ERR_get_error() {
     return _ERR_get_error();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ ffigen:
       - OPENSSL_version_major
       - OPENSSL_version_minor
       - OPENSSL_version_patch
+      - SSL_CTX_set_security_level
   macros:
     include:
       - BIO_C_SET_BUF_MEM_EOF_RETURN


### PR DESCRIPTION
This PR adds an additional parameter to the DTLS context classes that makes it possible to override the security level defined by OpenSSL. Lowering the security level allows for using cipher suites that have been deprecated in newer versions of OpenSSL, such as `TLS_PSK_WITH_AES_128_CCM_8` which is the mandatory cipher suite for CoAP (see [RFC 7252](https://www.rfc-editor.org/rfc/rfc7252.html#section-9.1.3.1)).

The examples are adjusted to make it clear what the new security level parameter is meant to do, while removing this aspect from the example in the README file in order not to overcomplicate things there.

Resolves #98.