### PR TITLE
ci: downgrade Dart version under Windows to 3.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,27 @@ on:
 
 jobs:
   build:
+    name: build (${{ matrix.os }})
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        # TODO: Remove once https://github.com/dart-lang/sdk/issues/55745
+        #       has been resolved
+        sdk: [stable, 3.3.0]
+        exclude:
+          - os: macos-latest
+            sdk: 3.3.0
+          - os: ubuntu-latest
+            sdk: 3.3.0
+          - os: windows-latest
+            sdk: stable
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
This PR adds a workaround for the currently hanging CI under Windows.