### PR TITLE
Fix linting issues, define and apply stricter linter configuration

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,9 +5,25 @@ include: package:lint/package.yaml
 analyzer:
   exclude:
     - 'lib/src/generated/ffi.dart'
+  errors:
+    public_member_api_docs: warning
 
+# Adjusted linting rules
 linter:
   rules:
     prefer_double_quotes: true
     unawaited_futures: true
     discarded_futures: true
+    sort_constructors_first: true
+    public_member_api_docs: true
+    comment_references: true
+    unnecessary_lambdas: true
+    lines_longer_than_80_chars: true
+    avoid_catches_without_on_clauses: true
+    use_to_and_as_if_applicable: true
+    avoid_returning_this: true
+    avoid_types_on_closure_parameters: true
+    avoid_slow_async_io: true
+    close_sinks: true
+    cascade_invocations: true
+    only_throw_errors: true

--- a/lib/src/dtls_alert.dart
+++ b/lib/src/dtls_alert.dart
@@ -194,14 +194,14 @@ enum AlertDescription {
 ///
 /// Consists of an [alertLevel] and a [alertDescription].
 class DtlsAlert {
+  /// Constructor.
+  DtlsAlert(this.alertLevel, this.alertDescription);
+
   /// The alert level of this alert.
   final AlertLevel alertLevel;
 
   /// The description of this alert.
   final AlertDescription alertDescription;
-
-  /// Constructor.
-  DtlsAlert(this.alertLevel, this.alertDescription);
 
   /// Generates a new [DtlsAlert] from the [code] passed in OpenSSL's info
   /// callback.

--- a/lib/src/dtls_client.dart
+++ b/lib/src/dtls_client.dart
@@ -88,10 +88,9 @@ class DtlsClient {
             }
           }
 
-          break;
         case RawSocketEvent.closed:
           await close();
-          break;
+
         case RawSocketEvent.readClosed:
         case RawSocketEvent.write:
           break;

--- a/lib/src/dtls_exception.dart
+++ b/lib/src/dtls_exception.dart
@@ -26,11 +26,11 @@ class DtlsHandshakeException extends DtlsException {
 
 /// [DtlsException] that indicates that a timeout has occured.
 class DtlsTimeoutException extends DtlsException implements TimeoutException {
-  @override
-  final Duration duration;
-
   /// Constructor.
   DtlsTimeoutException(super.message, this.duration);
+
+  @override
+  final Duration duration;
 
   @override
   String toString() => "DtlsTimeoutException after $duration: $message";

--- a/lib/src/dtls_server.dart
+++ b/lib/src/dtls_server.dart
@@ -121,10 +121,10 @@ class DtlsServer extends Stream<DtlsConnection> {
       switch (event) {
         case RawSocketEvent.read:
           await _handleSocketRead();
-          break;
+
         case RawSocketEvent.closed:
           await close();
-          break;
+
         case RawSocketEvent.readClosed:
         case RawSocketEvent.write:
           break;

--- a/lib/src/openssl_load_exception.dart
+++ b/lib/src/openssl_load_exception.dart
@@ -8,11 +8,11 @@
 /// to provide a fallback or throw their own [Exception]s
 /// if OpenSSL should not be available.
 class OpenSslLoadException implements Exception {
-  /// The actual error message.
-  final String libName;
-
   /// Constructor.
   OpenSslLoadException(this.libName);
+
+  /// The actual error message.
+  final String libName;
 
   @override
   String toString() {

--- a/lib/src/psk_credentials.dart
+++ b/lib/src/psk_credentials.dart
@@ -13,12 +13,12 @@ typedef PskCredentialsCallback = PskCredentials Function(
 /// Credentials used for PSK Cipher Suites consisting of an [identity]
 /// and a [preSharedKey].
 class PskCredentials {
+  /// Constructor
+  PskCredentials({required this.identity, required this.preSharedKey});
+
   /// The identity used with the [preSharedKey].
   Iterable<int> identity;
 
   /// The actual pre-shared key.
   Iterable<int> preSharedKey;
-
-  /// Constructor
-  PskCredentials({required this.identity, required this.preSharedKey});
 }

--- a/test/dtls_test.dart
+++ b/test/dtls_test.dart
@@ -122,7 +122,7 @@ void main() {
         const Skip(
           "on macOS, SSL_connct somehow fails. This needs to be fixed.",
         ),
-      ]
+      ],
     },
   );
 


### PR DESCRIPTION
This PR updates the `analysis_options.yaml` file with a slightly stricter configuration, and addresses existing and new hints provided by the linting step.