### PR TITLE
ci: use most recent OpenSSL version under Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,7 @@ jobs:
         run: dart analyze
 
       - name: Install OpenSSL (Windows)
-        run: |
-          choco install openssl --version=3.1.1
+        run: choco install openssl
         if: ${{ matrix.os == 'windows-latest' }}
 
       - name: Run tests with coverage


### PR DESCRIPTION
This PR removes the fixed version from the `choco install` command in the CI to let the respective workflow use the most recent version of OpenSSL under Windows. This might be revisited at a later point in time to test with multiple versions of OpenSSL.