### PR TITLE
ci: don't skip test under macOS

### DIFF
--- a/test/dtls_test.dart
+++ b/test/dtls_test.dart
@@ -38,6 +38,7 @@ Iterable<int>? _serverPskCallback(Iterable<int> identity) {
 final clientContext = DtlsClientContext(
   withTrustedRoots: true,
   ciphers: ciphers,
+  securityLevel: 0,
   pskCredentialsCallback: (receivedIdentityHint) {
     expect(receivedIdentityHint, identityHint);
 
@@ -52,6 +53,7 @@ final serverContext = DtlsServerContext(
   pskKeyStoreCallback: _serverPskCallback,
   ciphers: ciphers,
   identityHint: identityHint,
+  securityLevel: 0,
 );
 
 void main() {

--- a/test/dtls_test.dart
+++ b/test/dtls_test.dart
@@ -117,13 +117,6 @@ void main() {
 
       expect(connection.connected, isFalse);
     },
-    onPlatform: <String, dynamic>{
-      "mac-os": [
-        const Skip(
-          "on macOS, SSL_connct somehow fails. This needs to be fixed.",
-        ),
-      ],
-    },
   );
 
   test("Parse DTLS alerts", () {


### PR DESCRIPTION
Currently, there is one test being skipped under macOS. Since that does not seem to be necessary anymore, this PR re-enables the test for all platforms.

For the test to actually work, however, the security level needs to be lowered to still support the cipher suite `TLS_PSK_WITH_AES_128_CCM_8`. This will probably be revisited in upcoming PRs.