### PR TITLE
ci: use latest dart version on Windows again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # TODO: Remove once https://github.com/dart-lang/sdk/issues/55745
-        #       has been resolved
-        sdk: [stable, 3.3.0]
-        exclude:
-          - os: macos-latest
-            sdk: 3.3.0
-          - os: ubuntu-latest
-            sdk: 3.3.0
-          - os: windows-latest
-            sdk: stable
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
Since https://github.com/dart-lang/sdk/issues/55745 has been resolved in the meantime, the changes introduced by https://github.com/JKRhb/dtls2/pull/101 can now be reverted.