### PR TITLE
chore: downgrade meta package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   ffi: ^2.1.2
-  meta: ^1.16.0
+  meta: ^1.15.0
 
 dev_dependencies:
   ffigen: ^12.0.0


### PR DESCRIPTION
As the `meta` package is apparently pinned to version `1.15.0` in the Flutter SDK, the caret version `^1.16.0` that is used in this package apparently breaks Flutter compatibility. This PR hopefully resolves the issue.